### PR TITLE
Add geo data adapter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add geo data adapter to publish coordinates of c.geo.
+  [mathias.leimgruber]
 
 
 2.0.1 (2013-06-03)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -88,4 +88,13 @@
 
     </configure>
 
+    <configure zcml:condition="installed collective.geo.geographer">
+        <adapter
+              for="collective.geo.geographer.interfaces.IGeoreferenceable"
+              provides="ftw.publisher.core.interfaces.IDataCollector"
+              factory="ftw.publisher.core.adapters.geo_data.GeoData"
+              name="geo_data_adapter" />
+    </configure>
+
+
 </configure>

--- a/ftw/publisher/core/adapters/geo_data.py
+++ b/ftw/publisher/core/adapters/geo_data.py
@@ -1,0 +1,37 @@
+from AccessControl.SecurityInfo import ClassSecurityInformation
+from collective.geo.contentlocations.interfaces import IGeoManager
+from ftw.publisher.core import getLogger
+from ftw.publisher.core.interfaces import IDataCollector
+from zope.component import queryAdapter
+from zope.interface import implements
+
+
+class GeoData(object):
+    """returns geo data
+    """
+
+    implements(IDataCollector)
+    logger = getLogger()
+    security = ClassSecurityInformation()
+
+    def __init__(self, obj):
+        self.object = obj
+        self.manager = queryAdapter(obj, IGeoManager)
+
+    security.declarePrivate('getData')
+    def getData(self):
+        if self.manager:
+            return self.manager.getCoordinates()
+        else:
+            return None
+
+    security.declarePrivate('setData')
+    def setData(self, geodata, metadata):
+        self.logger.info('Updating geo data (UID %s)' %
+                (self.object.UID())
+        )
+
+        if geodata == (None, None):
+            self.manager.removeCoordinates()
+        else:
+            self.manager.setCoordinates(*geodata)

--- a/ftw/publisher/core/tests/test_geo_data_adapter.py
+++ b/ftw/publisher/core/tests/test_geo_data_adapter.py
@@ -1,0 +1,60 @@
+from collective.geo.contentlocations.interfaces import IGeoManager
+from collective.geo.geographer.interfaces import IGeoreferenceable
+from ftw.publisher.core.interfaces import IDataCollector
+from ftw.publisher.core.testing import ZCML_LAYER
+from ftw.testing import MockTestCase
+from zope.annotation import IAttributeAnnotatable
+from zope.component import getAdapter
+from zope.component import queryAdapter
+
+
+class TestGeoDataAdapter(MockTestCase):
+
+    layer = ZCML_LAYER
+
+    def setUp(self):
+        super(TestGeoDataAdapter, self).setUp()
+
+        self.obj = self.providing_stub(
+            [IGeoreferenceable, IAttributeAnnotatable])
+
+    def test_component_registered_and_implements_interface(self):
+        self.replay()
+
+        component = getAdapter(self.obj, IDataCollector,
+                               name='geo_data_adapter')
+        self.assertTrue(IDataCollector.providedBy(component),
+                        'geo Adapter is not registered properly')
+
+    def test_getData_no_coordinates(self):
+        self.replay()
+
+        component = getAdapter(self.obj, IDataCollector,
+                               name='geo_data_adapter')
+
+        self.assertEquals((None, None), component.getData())
+
+    def test_getData_with_coordinates(self):
+        self.replay()
+
+        data = 'Point', (0.222, 0.111)
+        component = getAdapter(self.obj, IDataCollector,
+                               name='geo_data_adapter')
+
+        manager = queryAdapter(self.obj, IGeoManager)
+        manager.setCoordinates(*data)
+
+        self.assertEquals(data, component.getData())
+
+    def test_setData(self):
+        self.replay()
+        setattr(self.obj, 'UID', lambda: 'test-uid')
+
+        data = 'Point', (0.222, 0.111)
+        component = getAdapter(self.obj, IDataCollector,
+                               name='geo_data_adapter')
+
+        component.setData(data, {})
+        manager = queryAdapter(self.obj, IGeoManager)
+
+        self.assertEquals(data, manager.getCoordinates())

--- a/ftw/publisher/core/tests/tests.zcml
+++ b/ftw/publisher/core/tests/tests.zcml
@@ -2,8 +2,22 @@
            i18n_domain="Five">
 
     <include package="Products.Five" file="meta.zcml" />
+    <include package="zope.annotation" />
 
     <include package="AccessControl" />
     <include package="Products.Five.utilities" file="configure.zcml" />
+
+
+    <!-- Manually register the necessary c.geo adapters -->
+    <adapter
+        for="collective.geo.geographer.interfaces.IGeoreferenceable"
+        provides="collective.geo.contentlocations.interfaces.IGeoManager"
+        factory="collective.geo.contentlocations.geomanager.GeoManager" />
+
+    <adapter
+        factory="collective.geo.geographer.geo.GeoreferencingAnnotator"
+        provides="collective.geo.geographer.interfaces.IWriteGeoreferenced"
+        trusted="true"
+        />
 
 </configure>

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ extras_require['tests'] = tests_require = [
     'unittest2',
     'zope.annotation',
     'zope.configuration',
+    'collective.geo.geographer',
+    'collective.geo.contentlocations',
 
     ] + reduce(list.__add__, extras_require.values())
 


### PR DESCRIPTION
This is used to publish geo data. The coordinates are stored in annotations using the `IGeoManager` of `collective.geo.contentlocations.interfaces`
