### PR TITLE
Fix Unauthorized exception in back references adapter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Unauthorized exception in back references adapter
+  caused by Products.PloneHotfix20130618.
+  [jone]
 
 
 2.1.0 (2013-06-13)

--- a/ftw/publisher/core/adapters/backreferences.py
+++ b/ftw/publisher/core/adapters/backreferences.py
@@ -1,10 +1,15 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
+from AccessControl import getSecurityManager
+from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import setSecurityManager
+from AccessControl.SecurityManagement import SpecialUsers
 from Acquisition import aq_base
 from Products.Archetypes.interfaces.referenceable import IReferenceable
 from Products.CMFCore.utils import getToolByName
 from ftw.publisher.core import getLogger
 from ftw.publisher.core.interfaces import IDataCollector
 from zope.interface import implements
+import AccessControl
 
 
 class Backreferences(object):
@@ -51,7 +56,14 @@ class Backreferences(object):
                 # plone.app.referenceablebehavior activated.
                 return data
 
-        for ref in referenceable.getBackReferenceImpl():
+        old_security_manager = getSecurityManager()
+        newSecurityManager(self.context.REQUEST, SpecialUsers.system)
+        try:
+            references = referenceable.getBackReferenceImpl()
+        finally:
+            setSecurityManager(old_security_manager)
+
+        for ref in references:
             # get source object
             src = ref.getSourceObject()
             suid = src.UID()


### PR DESCRIPTION
The problem is caused by PloneHotfix20130618.
Calling `getBackReferenceImpl` might raise an `Unauthorized`.

The fix is to switch to system security for the `getBackReferenceImpl` call, so that we also get objects where the current user has no access. This is by intention because also objects invisible to the current user should be respected.

/cc @maethu 
