### PR TITLE
Implement simplelayout block adapter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 2.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Implement simplelayout block adapter.
+  The adapter adds publisher support for simplelayout block settings,
+  such as dimensions, height, position etc.
+  [jone]
 
 
 2.2 (2013-07-18)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -104,4 +104,12 @@
               name="shop_item_adapter" />
     </configure>
 
+    <configure zcml:condition="installed simplelayout.base">
+        <adapter
+            for="simplelayout.base.interfaces.ISimpleLayoutBlock"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".simplelayout_blocks.SimplelayoutBlockDataCollector"
+            name="simplelayout_block" />
+    </configure>
+
 </configure>

--- a/ftw/publisher/core/adapters/simplelayout_blocks.py
+++ b/ftw/publisher/core/adapters/simplelayout_blocks.py
@@ -1,0 +1,34 @@
+from ftw.publisher.core.interfaces import IDataCollector
+from simplelayout.base.interfaces import IBlockConfig
+from simplelayout.base.interfaces import ISimpleLayoutBlock
+from zope.component import adapts
+from zope.interface import implements
+
+
+ATTRIBUTES = ['block_height',
+              'image_layout',
+              'viewlet_manager',
+              'viewname']
+
+
+class SimplelayoutBlockDataCollector(object):
+    implements(IDataCollector)
+    adapts(ISimpleLayoutBlock)
+
+    def __init__(self, context):
+        self.context = context
+
+    def getData(self):
+        config = IBlockConfig(self.context)
+        data = {}
+
+        for attr in ATTRIBUTES:
+            data[attr] = getattr(config, attr)
+
+        return data
+
+    def setData(self, data, metadata):
+        config = IBlockConfig(self.context)
+
+        for attr in ATTRIBUTES:
+            setattr(config, attr, data[attr])

--- a/ftw/publisher/core/tests/test_simplelayout_adapter.py
+++ b/ftw/publisher/core/tests/test_simplelayout_adapter.py
@@ -1,0 +1,52 @@
+from ftw.testing import MockTestCase
+from ftw.publisher.core.adapters import simplelayout_blocks
+from simplelayout.base.interfaces import IBlockConfig
+from simplelayout.base.interfaces import ISimpleLayoutBlock
+
+
+class TestSimplelayoutDataCollector(MockTestCase):
+
+    def setUp(self):
+        super(TestSimplelayoutDataCollector, self).setUp()
+
+        self.obj = self.providing_stub(ISimpleLayoutBlock)
+
+        Config = self.stub()
+        self.config = self.mock_interface(IBlockConfig)
+        self.expect(Config(self.obj)).result(self.config)
+        self.mock_adapter(Config, IBlockConfig, [ISimpleLayoutBlock])
+
+    def test_getData(self):
+        self.expect(self.config.block_height).result(None)
+        self.expect(self.config.image_layout).result('foo')
+        self.expect(self.config.viewlet_manager).result('bar')
+        self.expect(self.config.viewname).result('baz')
+
+        self.replay()
+
+        collector = simplelayout_blocks.SimplelayoutBlockDataCollector(
+            self.obj)
+
+        self.assertEqual(collector.getData(),
+                         {'block_height': None,
+                          'image_layout': 'foo',
+                          'viewlet_manager': 'bar',
+                          'viewname': 'baz'})
+
+    def test_setData(self):
+        # expect:
+        self.config.block_height = None
+        self.config.image_layout = 'foo'
+        self.config.viewlet_manager = 'bar'
+        self.config.viewname = 'baz'
+
+        self.replay()
+
+        input = {'block_height': None,
+                 'image_layout': 'foo',
+                 'viewlet_manager': 'bar',
+                 'viewname': 'baz'}
+
+        collector = simplelayout_blocks.SimplelayoutBlockDataCollector(
+            self.obj)
+        collector.setData(input, {})

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras_require['tests'] = tests_require = [
     'zope.configuration',
     'collective.geo.geographer',
     'collective.geo.contentlocations',
+    'simplelayout.base',
     'ftw.shop',
 
     ] + reduce(list.__add__, extras_require.values())


### PR DESCRIPTION
The adapter adds publisher support for simplelayout block settings,
such as dimensions, height, position etc.

@maethu I've taken this from izug.organisation. We need to remove it from there when we update ftw.publisher.core..
