### PR TITLE
plonetheme.onegov: publish custom styles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,10 +5,6 @@ Changelog
 2.3.4 (unreleased)
 ------------------
 
-- Drop Plone 4.2 compatibility, since plonetheme.onegov is only Plone 4.3
-  compatible. If you are not using plonetheme.onegov the publisher may work
-  also on older Plone versions.
-
 - plonetheme.onegov: Support custom styles.
   [mathias.leimgruber]
 

--- a/ftw/publisher/core/testing.py
+++ b/ftw/publisher/core/testing.py
@@ -15,8 +15,17 @@ from plone.portlets.interfaces import IPortletManager
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.configuration import xmlconfig
-from zope.interface import alsoProvides
 from zope.interface import Interface
+from zope.interface import alsoProvides
+import pkg_resources
+
+
+try:
+    pkg_resources.get_distribution('plonetheme.onegov')
+except pkg_resources.DistributionNotFound:
+    ONEGOV_THEME_INSTALLED = False
+else:
+    ONEGOV_THEME_INSTALLED = True
 
 
 #Dummy Interfaces
@@ -56,10 +65,12 @@ class PublisherCoreLayer(PloneSandboxLayer):
         import ftw.publisher.core
         xmlconfig.file('configure.zcml', ftw.publisher.core,
                        context=configurationContext)
-        # Load ZCML
-        import plonetheme.onegov
-        xmlconfig.file('configure.zcml', plonetheme.onegov,
-                       context=configurationContext)
+
+        if ONEGOV_THEME_INSTALLED:
+            # Load ZCML
+            import plonetheme.onegov
+            xmlconfig.file('configure.zcml', plonetheme.onegov,
+                           context=configurationContext)
 
 PUBLISHER_CORE_FIXTURE = PublisherCoreLayer()
 PUBLISHER_CORE_INTEGRATION_TESTING = IntegrationTesting(

--- a/ftw/publisher/core/tests/test_custom_style_adapter.py
+++ b/ftw/publisher/core/tests/test_custom_style_adapter.py
@@ -1,15 +1,16 @@
 from ftw.publisher.core.interfaces import IDataCollector
+from ftw.publisher.core.testing import ONEGOV_THEME_INSTALLED
 from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
-from plone.app.testing import login
-from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from plonetheme.onegov.interfaces import ICustomStyles
-from unittest2 import TestCase
+from plone.app.testing import login
+from plone.app.testing import setRoles
 from zope.component import getAdapter
+import unittest2
 
 
-class TestCustomStyling(TestCase):
+
+class TestCustomStyling(unittest2.TestCase):
 
     layer = PUBLISHER_CORE_INTEGRATION_TESTING
 
@@ -18,10 +19,14 @@ class TestCustomStyling(TestCase):
         setRoles(self.portal, TEST_USER_ID, ['Manager'])
         login(self.portal, TEST_USER_NAME)
 
-        self.custom = ICustomStyles(self.portal)
-        self.input_ = {'css.body-background': 'red'}
-        self.custom.set_styles(self.input_)
+        if ONEGOV_THEME_INSTALLED:
+            from plonetheme.onegov.interfaces import ICustomStyles
+            self.custom = ICustomStyles(self.portal)
+            self.input_ = {'css.body-background': 'red'}
+            self.custom.set_styles(self.input_)
 
+    @unittest2.skipUnless(ONEGOV_THEME_INSTALLED,
+                          'plonetheme.onegov not installed')
     def test_custom_style_getter(self):
         component = getAdapter(self.portal, IDataCollector,
                                name='custom_style_adapter')
@@ -29,6 +34,8 @@ class TestCustomStyling(TestCase):
         data = component.getData()
         self.assertEquals(self.input_, data)
 
+    @unittest2.skipUnless(ONEGOV_THEME_INSTALLED,
+                          'plonetheme.onegov not installed')
     def test_custom_style_setter(self):
         self.custom.set_styles({})
         component = getAdapter(self.portal, IDataCollector,

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ extras_require['tests'] = tests_require = [
     'ftw.contentpage',
     'ftw.shop',
     'ftw.builder',
-    'plonetheme.onegov',
 
     ] + reduce(list.__add__, extras_require.values())
 

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+
+package-name = ftw.publisher.core

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -3,3 +3,8 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
 
 package-name = ftw.publisher.core
+
+
+[test]
+eggs +=
+    plonetheme.onegov


### PR DESCRIPTION
Use the ICustomStyle Adapter to publish theme customization

Currently it's not possible to invalidate the cache on all instances, but this is a plonetheme.onegov issue.
