### PR TITLE
BugFix in property adapter: Setting a property can raise a AttributeError

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,10 @@ Changelog
 2.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- BugFix in property adapter: Setting a property can raise a AttributeError
+  if the content type influence the property behavior.
+  Example see https://github.com/seantis/seantis.dir.contacts/blob/a0360a35e41afb1a8e0fa4ff553b423e0f731eee/seantis/dir/contacts/contact.py#L83
+  [mathias.leimgruber]
 
 2.4.0 (2014-02-04)
 ------------------

--- a/ftw/publisher/core/adapters/properties_data.py
+++ b/ftw/publisher/core/adapters/properties_data.py
@@ -112,9 +112,14 @@ class PropertiesData(object):
 
             if prop['id'] in currentProperties:
                 # update property if existing ...
-                self.object._updateProperty(
-                    id=prop['id'],
-                    value=val)
+                try:
+                    self.object._updateProperty(
+                        id=prop['id'],
+                        value=val)
+                except AttributeError:
+                    self.logger.info(
+                        'Could not set property "{0}" on {1}'.format(
+                            prop['id'], uid))
 
             else:
                 # ... otherwise


### PR DESCRIPTION
This case raises a AttributeError Example see https://github.com/seantis/seantis.dir.contacts/blob/a0360a35e41afb1a8e0fa4ff553b423e0f731eee/seantis/dir/contacts/contact.py#L83
