### PR TITLE
Drop Plone 4.3.5 support for now (not testing against it).

### DIFF
--- a/test-plone-4.3.4.cfg
+++ b/test-plone-4.3.4.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.4.cfg
 
 package-name = ftw.publisher.core
 


### PR DESCRIPTION
We have a problem when comparing text values:

https://github.com/plone/Products.CMFPlone/issues/532

This breaks our tests and our implementation, so we drop the support for now.