### PR TITLE
Support dexterity relations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support dexterity relations.
+  [jone]
 
 
 2.4.1 (2014-12-02)

--- a/ftw/publisher/core/tests/profiles/dexterity/types/ExampleDxType.xml
+++ b/ftw/publisher/core/tests/profiles/dexterity/types/ExampleDxType.xml
@@ -19,6 +19,7 @@
     <property name="behaviors">
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
         <element value="plone.app.content.interfaces.INameFromTitle" />
+        <element value="plone.app.relationfield.behavior.IRelatedItems"/>
     </property>
 
     <!-- View information -->

--- a/ftw/publisher/core/tests/test_dexterity.py
+++ b/ftw/publisher/core/tests/test_dexterity.py
@@ -4,9 +4,10 @@ from ftw.publisher.core.testing import PUBLISHER_EXAMPLE_CONTENT_FIXTURE
 from ftw.publisher.core.tests.interfaces import ITextSchema
 from json import dumps
 from json import loads
+from plone.app.relationfield.behavior import IRelatedItems
+from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.app.textfield.value import RichTextValue
 from plone.dexterity.utils import createContentInContainer
 from plone.namedfile.file import NamedFile
@@ -74,7 +75,8 @@ class TestDexterityFieldData(TestCase):
 
         self.assertEquals({'IBasic': {'description': u'',
                                       'title': u'My Object'},
-                           'IFoo': {}},
+                           'IFoo': {},
+                           'IRelatedItems': {'relatedItems': []}},
 
                           self._get_field_data(obj))
 
@@ -134,3 +136,13 @@ class TestDexterityFieldData(TestCase):
 
         self.assertEquals(RichTextValue, type(target.text))
         self.assertEquals(textdata, target.text.raw)
+
+    def test_relations_when_target_is_available(self):
+        foo = createContentInContainer(self.portal, 'ExampleDxType', title=u'Foo')
+        source = createContentInContainer(self.portal, 'ExampleDxType', title=u'Item')
+        IRelatedItems(source).relatedItems = [foo]
+
+        data = self._get_field_data(source, json=True)
+        target = createContentInContainer(self.portal, 'ExampleDxType')
+        self._set_field_data(target, data, json=True)
+        self.assertEquals([foo], target.relatedItems)

--- a/setup.py
+++ b/setup.py
@@ -14,21 +14,22 @@ extras_require['tests'] = tests_require = [
 
     'Acquisition',
     'Plone',
+    'collective.geo.contentlocations',
+    'collective.geo.geographer',
     'collective.testcaselayer',
+    'ftw.builder',
+    'ftw.contentpage',
+    'ftw.shop',
     'ftw.testing',
     'plone.app.blob',
+    'plone.app.relationfield',
     'plone.app.testing',
     'plone.directives.form',
     'plone.namedfile',
+    'simplelayout.base',
     'unittest2',
     'zope.annotation',
     'zope.configuration',
-    'collective.geo.geographer',
-    'collective.geo.contentlocations',
-    'simplelayout.base',
-    'ftw.contentpage',
-    'ftw.shop',
-    'ftw.builder',
 
     ] + reduce(list.__add__, extras_require.values())
 


### PR DESCRIPTION
This adds support for already published related objects.
It does not support updating backreferences for dexterity objects yet.