### PR TITLE
Keep tuple / set types when sending data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
+- Keep tuple / set types when sending data.
+  [jone]
+
 - Support dexterity relations.
   [jone]
 

--- a/ftw/publisher/core/tests/test_utils.py
+++ b/ftw/publisher/core/tests/test_utils.py
@@ -46,25 +46,31 @@ class TestEncodeDecodeJson(MockTestCase):
         result = self.transport(data, additional_encodings=['GB18030'])
         self.assertEqual(result, data)
 
+    def test_unicode(self):
+        transported = self.transport(u'foo')
+        self.assertEqual(u'foo', transported)
+        self.assertEqual(unicode, type(transported))
+
+    def test_empty_unicode(self):
+        transported = self.transport(u'')
+        self.assertEqual(u'', transported)
+        self.assertEqual(unicode, type(transported))
+
     def test_list(self):
         input = ['foo', 'bar']
         output = self.transport(input)
         self.assertEqual(output, input)
         self.assertEqual(type(output), type(input))
 
-    def test_tuple_becomes_list(self):
-        input = ('foo', 'bar')
-        output = self.transport(input)
-        self.assertEqual(list(output), list(input))
-        self.assertNotEqual(type(output), type(input))
-        self.assertEqual(type(output), list)
+    def test_tuple(self):
+        transported = self.transport((1, 2))
+        self.assertEqual((1, 2), transported)
+        self.assertEqual(tuple, type(transported))
 
-    def test_set_becomes_list(self):
-        input = set(['foo', 'bar'])
-        output = self.transport(input)
-        self.assertEqual(list(output), list(input))
-        self.assertNotEqual(type(output), type(input))
-        self.assertEqual(type(output), list)
+    def test_set(self):
+        transported = self.transport({1, 2})
+        self.assertEqual({1, 2}, transported)
+        self.assertEqual(set, type(transported))
 
     def test_dict(self):
         input = {'foo': 'bar', 'bar': 'baz'}

--- a/ftw/publisher/core/utils.py
+++ b/ftw/publisher/core/utils.py
@@ -149,12 +149,21 @@ def decode_for_json(value, additional_encodings=[]):
                 pass
         raise
 
-    # lists, tuples, sets
-    elif isinstance(value, (list, tuple, set)):
+
+    # list
+    elif isinstance(value, list):
         nval = []
         for sval in value:
             nval.append(decode_for_json(sval))
         return nval
+
+    # tuple
+    elif isinstance(value, tuple):
+        return decode_for_json(['tuple', list(value)])
+
+    # set
+    elif isinstance(value, set):
+        return decode_for_json(['set', list(value)])
 
     # dicts
     elif isinstance(value, dict):
@@ -198,17 +207,15 @@ def encode_after_json(value):
         else:
             return nval.encode(encoding)
 
-    # lists, tuples, sets
-    elif type(value) in (list, tuple, set):
-        nval = []
-        for sval in value:
-            nval.append(encode_after_json(sval))
-        if isinstance(value, tuple):
-            return tuple(nval)
-        elif isinstance(value, set):
-            return set(nval)
+    # list, tuple, set
+    elif isinstance(value, list):
+        new_value = map(encode_after_json, value)
+        if len(new_value) == 2 and new_value[0] == 'tuple':
+            return tuple(new_value[1])
+        elif len(new_value) == 2 and new_value[0] == 'set':
+            return set(new_value[1])
         else:
-            return nval
+            return new_value
 
     # OOBTree
     elif isinstance(value, dict) and \


### PR DESCRIPTION
tuples and sets were converted to lists.
With dexterity it is important that those types are kept and not converted to lists.

@maethu 