### PR TITLE
dx references: fix wrong object problem.

### DIFF
--- a/ftw/publisher/core/adapters/dx_field_data.py
+++ b/ftw/publisher/core/adapters/dx_field_data.py
@@ -172,9 +172,11 @@ class DexterityFieldData(object):
             if value.isBroken():
                 return ['raw', None]
 
-            return ['RelationValue', value.to_path]
+            return ['RelationValue',
+                    utils.make_path_relative(value.to_path)]
 
-        return ['obj', '/'.join(value.getPhysicalPath())]
+        return ['obj',
+                utils.get_relative_path(value)]
 
     def _unpack_relation(self, value):
         valuetype, value = value
@@ -185,12 +187,10 @@ class DexterityFieldData(object):
             return value
 
         if valuetype == 'RelationValue':
-            site = getToolByName(self.context, 'portal_url').getPortalObject()
-            obj = site.unrestrictedTraverse(value, None)
+            obj = utils.get_obj_by_relative_path(value)
             if not obj:
                 return None
             return utils.create_relation_for(obj)
 
         if valuetype == 'obj':
-            site = getToolByName(self.context, 'portal_url').getPortalObject()
-            return site.unrestrictedTraverse(value, None)
+            return utils.get_obj_by_relative_path(value)

--- a/ftw/publisher/core/tests/test_utils.py
+++ b/ftw/publisher/core/tests/test_utils.py
@@ -1,7 +1,13 @@
 from DateTime import DateTime
 from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.publisher.core import utils
+from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
 from ftw.testing import MockTestCase
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from unittest2 import TestCase
 import json
 
 
@@ -113,3 +119,34 @@ class TestEncodeDecodeJson(MockTestCase):
         output = self.transport(input)
         self.assertEqual(input, output)
         self.assertEqual(type(input), type(output))
+
+
+class TestPathFunctions(TestCase):
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+    def test_make_path_relative(self):
+        self.assertEquals(
+            'the-folder/the-page',
+            utils.make_path_relative('/plone/the-folder/the-page'))
+
+    def test_get_relative_path(self):
+        folder = create(Builder('folder').titled('The Folder'))
+        page = create(Builder('page').titled('The Page').within(folder))
+        self.assertEquals(
+            'the-folder/the-page',
+            utils.get_relative_path(page))
+
+    def test_get_obj_by_relative_path(self):
+        folder = create(Builder('folder').titled('The Folder'))
+        page = create(Builder('page').titled('The Page').within(folder))
+        self.assertEquals(
+            page,
+            utils.get_obj_by_relative_path('the-folder/the-page'))
+
+    def test_get_obj_by_relative_path_returns_None_when_object_missing(self):
+        self.assertEquals(
+            None,
+            utils.get_obj_by_relative_path('the-folder/the-page'))

--- a/ftw/publisher/core/utils.py
+++ b/ftw/publisher/core/utils.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from plone.portlets.settings import PortletAssignmentSettings
 from ZConfig.components.logger import loghandler
 from zope.component import getUtility
+from zope.component.hooks import getSite
 import logging
 import os.path
 import pkg_resources
@@ -257,6 +258,42 @@ def encode_after_json(value):
     # other types
     else:
         return value
+
+
+def make_path_relative(path):
+    """Make an absolute path relative to the site root.
+    """
+    site_path = '/'.join(getSite().getPhysicalPath())
+    assert path.startswith(site_path), (
+        'The obj path "{0}" does not start with the site path "{1}"'.format(
+            path, site_path))
+
+    return path[len(site_path + '/'):]
+
+
+def get_relative_path(obj):
+    """Returns the path to an object relative to the site root.
+    """
+    site_path = '/'.join(getSite().getPhysicalPath())
+    obj_path = '/'.join(obj.getPhysicalPath())
+    assert obj_path.startswith(site_path), (
+        'The obj path "{0}" does not start with the site path "{1}"'.format(
+            obj_path, site_path))
+
+    return obj_path[len(site_path + '/'):]
+
+
+def get_obj_by_relative_path(relative_path):
+    """Returns the object by a path relative to the site root.
+    If no object is found, None is returned.
+    Bad acquisition lookups are eliminiated.
+    """
+    site_path = '/'.join(getSite().getPhysicalPath())
+    obj_path = '/'.join((site_path, relative_path.strip('/')))
+    obj = getSite().restrictedTraverse(obj_path, None)
+    if not obj or '/'.join(obj.getPhysicalPath()) != obj_path:
+        return None
+    return obj
 
 
 try:


### PR DESCRIPTION
The problem is that when source and target Plone sites run on the same
Zope instance dexterity relations may be looked up wrong.
When an the relation target is not yet on the target site it is
found from the target site on the source site when queried with the
absolute path.
Therefore we should always use relative paths when putting paths on the wire.