### PR TITLE
Prevent "ValueError: Description must be unicode."

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- Prevent "ValueError: Description must be unicode." for dexterity objects.
+  [jone]
+
 - Add support for PersistentList and PersistentMapping in decode_for_json-utility.
   [elioschmutz, mbaechtold]
 

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -137,11 +137,24 @@
             provides="ftw.publisher.core.interfaces.IDataCollector"
             factory=".ftw_simplelayout.SimplelayoutPageAnnotations"
             name="ftw.simplelayout:SimplelayoutPageAnnotations" />
+
         <adapter
             for="ftw.simplelayout.interfaces.ISimplelayoutBlock"
             provides="ftw.publisher.core.interfaces.IDataCollector"
             factory=".ftw_simplelayout.SimplelayoutBlockAnnotations"
             name="ftw.simplelayout:SimplelayoutBlockAnnotations" />
+
+        <adapter
+            for="ftw.simplelayout.interfaces.ISimplelayoutBlock"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".ftw_simplelayout.RemoveDeletedSLContentishChildren"
+            name="ftw.simplelayout:RemoveDeletedSLContentishChildren" />
+
+        <adapter
+            for="ftw.simplelayout.interfaces.ISimplelayout"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".ftw_simplelayout.RemoveDeletedSLContentishChildren"
+            name="ftw.simplelayout:RemoveDeletedSLContentishChildren" />
     </configure>
 
 </configure>

--- a/ftw/publisher/core/adapters/dx_field_data.py
+++ b/ftw/publisher/core/adapters/dx_field_data.py
@@ -79,8 +79,16 @@ class DexterityFieldData(object):
             for name, field in schema.getFieldsInOrder(schemata):
                 value = subdata[name]
                 value = self.unpack(name, field, value)
-                if value != _marker:
-                    setattr(repr, name, value)
+                if value == _marker:
+                    continue
+
+                if name == 'description' and value == '' and isinstance(value, str):
+                    # Prevent ValueError: Description must be unicode.
+                    # Dexterity has a wrong default description which is str instead
+                    # of unicode.
+                    value = u''
+
+                setattr(repr, name, value)
 
     def pack(self, name, field, value):
         """Packs the field data and makes it ready for transportation with

--- a/ftw/publisher/core/adapters/ftw_simplelayout.py
+++ b/ftw/publisher/core/adapters/ftw_simplelayout.py
@@ -1,9 +1,64 @@
 from AccessControl.SecurityInfo import ClassSecurityInformation
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.publisher.core.interfaces import IDataCollector
 from ftw.simplelayout.handlers import unwrap_persistence
 from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.simplelayout.interfaces import ISimplelayout
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from operator import methodcaller
+from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope.interface import implements
+
+
+marker = object()
+
+
+def is_sl_contentish(context):
+    """This method returns True when the object is considered
+    simplelayout contentish.
+
+    Being simplelayout contentish means that the object, usually a block,
+    has the same publishing cycle as the parent (page).
+    This behavior may be recursive (e.g. files in filelistingblocks).
+
+    An object is considered simplelayout contentish when:
+    - it has no workflow and it is a simplelayout block
+    - it has no workflow and the parent is a simplelayout block without
+    workflow
+
+    When a SL contentish object is deleted on the sender side (redaction),
+    it is not directly deleted with a push job, since it is part of the
+    content.
+    When the SL container (page) is published, it will be removed.
+    """
+
+    if IPloneSiteRoot.providedBy(context):
+        # Abort recursion when site root reached.
+        return False
+
+    if ISimplelayout.providedBy(context):
+        # Abort recursion when simplelayout page reached.
+        return False
+
+    wftool = getToolByName(context, 'portal_workflow')
+    if wftool.getWorkflowsFor(context):
+        # The object has a workflow and is therefore not considered sl
+        # contentish, since it has its own publishing cycle.
+        return False
+
+    if ISimplelayoutBlock.providedBy(context):
+        # A block without workflow is always considered sl contentish.
+        return True
+
+    # We have an object whithout a workflow.
+    # It is considered sl contentish when the parent is sl contentish.
+    # It is not considered sl contentish when it is directly in the page.
+    parent = aq_parent(aq_inner(context))
+    return is_sl_contentish(parent)
 
 
 class SimplelayoutPageAnnotations(object):
@@ -36,3 +91,32 @@ class SimplelayoutBlockAnnotations(object):
     security.declarePrivate('setData')
     def setData(self, data, metadata):
         IBlockConfiguration(self.context).store(data)
+
+
+class RemoveDeletedSLContentishChildren(object):
+    implements(IDataCollector)
+    security = ClassSecurityInformation()
+
+    def __init__(self, context):
+        self.context = context
+
+    security.declarePrivate('getData')
+    def getData(self):
+        return self._get_contentish_children_uuids()
+
+    security.declarePrivate('setData')
+    def setData(self, data, metadata):
+        sender_uuids = data
+        receiver_uuids = self._get_contentish_children_uuids()
+        uuids_to_delete = set(receiver_uuids) - set(sender_uuids)
+        children_to_delete = self._get_children_by_uuids(uuids_to_delete)
+        self.context.manage_delObjects(map(methodcaller('getId'),
+                                           children_to_delete))
+
+    def _get_contentish_children_uuids(self):
+        return map(IUUID, filter(is_sl_contentish,
+                                 self.context.objectValues()))
+
+    def _get_children_by_uuids(self, uuids):
+        return filter(lambda obj: IUUID(obj, marker) in uuids,
+                      self.context.objectValues())

--- a/ftw/publisher/core/tests/test_ftw_simplelayout_adapters.py
+++ b/ftw/publisher/core/tests/test_ftw_simplelayout_adapters.py
@@ -1,15 +1,64 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.publisher.core.adapters.ftw_simplelayout import is_sl_contentish
 from ftw.publisher.core.interfaces import IDataCollector
 from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
-from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import IBlockConfiguration
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.testing import staticuid
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
 from zope.component import getAdapter
 import json
+
+
+class TestSimplelayoutContentish(TestCase):
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    def test_plone_site_is_not_sl_contentish(self):
+        self.assertFalse(is_sl_contentish(self.portal))
+
+    def test_content_page_is_not_sl_contentish(self):
+        page = create(Builder('sl content page').titled(u'The Page'))
+        self.assertFalse(is_sl_contentish(page))
+
+    def test_textblock_is_contentish(self):
+        block = create(Builder('sl textblock')
+                       .within(create(Builder('sl content page'))))
+        self.assertTrue(is_sl_contentish(block))
+
+    def test_textblock_with_workflow_is_not_contentish(self):
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.setChainForPortalTypes(['ftw.simplelayout.TextBlock'], 'plone_workflow')
+        block = create(Builder('sl textblock')
+                       .within(create(Builder('sl content page'))))
+        self.assertFalse(is_sl_contentish(block))
+
+    def test_listingblock_is_contentish(self):
+        block = create(Builder('sl listingblock')
+                       .within(create(Builder('sl content page'))))
+        self.assertTrue(is_sl_contentish(block))
+
+    def test_file_in_listingblock_is_contentish(self):
+        document = create(Builder('file')
+                          .within(create(Builder('sl listingblock')
+                                         .within(create(Builder('sl content page'))))))
+        self.assertTrue(is_sl_contentish(document))
+
+    def test_file_with_workflow_in_listingblock_is_not_contentish(self):
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.setChainForPortalTypes(['File'], 'plone_workflow')
+        document = create(Builder('file')
+                          .within(create(Builder('sl listingblock')
+                                         .within(create(Builder('sl content page'))))))
+        self.assertFalse(is_sl_contentish(document))
 
 
 class TestSimplelayoutPageAnnotations(TestCase):
@@ -102,3 +151,115 @@ class TestSimplelayoutBlockAnnotations(TestCase):
         component.setData({'scale': 'sl_textblock_small'}, {})
         self.assertEquals({'scale': 'sl_textblock_small'},
                           IBlockConfiguration(block).load())
+
+
+class TestRemoveDeletedSLContentishChildren(TestCase):
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+
+    @staticuid('staticuid')
+    def test_getter_on_page_returns_contentish_block_uids(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        create(Builder('sl textblock').titled(u'TextBlock').within(page))
+        create(Builder('sl listingblock').titled(u'Listing').within(page))
+        create(Builder('sl content page').titled(u'SubPage').within(page))
+
+        component = getAdapter(page, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+        self.assertEquals([u'staticuid00000000000000000000002',
+                           u'staticuid00000000000000000000003'],
+                          json.loads(json.dumps(component.getData())))
+
+    @staticuid('staticuid')
+    def test_setter_on_page_deletes_not_listed_blocks(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        create(Builder('sl textblock').titled(u'TextBlock').within(page))
+        create(Builder('sl listingblock').titled(u'Listing').within(page))
+        create(Builder('sl content page').titled(u'SubPage').within(page))
+
+        component = getAdapter(page, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+
+        self.assertEquals(['textblock', 'listing', 'subpage'], page.objectIds())
+        component.setData([u'staticuid00000000000000000000002'], {})
+        self.assertEquals(['textblock', 'subpage'], page.objectIds())
+
+    @staticuid('staticuid')
+    def test_getter_on_plone_site_returns_contentish_block_uids(self):
+        create(Builder('sl textblock').titled(u'TextBlock').within(self.portal))
+        create(Builder('sl listingblock').titled(u'Listing').within(self.portal))
+        create(Builder('sl content page').titled(u'SubPage').within(self.portal))
+
+        component = getAdapter(self.portal, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+        self.assertEquals([u'staticuid00000000000000000000001',
+                           u'staticuid00000000000000000000002'],
+                          json.loads(json.dumps(component.getData())))
+
+    @staticuid('staticuid')
+    def test_setter_on_plone_site_deletes_not_listed_blocks(self):
+        create(Builder('sl textblock').titled(u'TextBlock').within(self.portal))
+        create(Builder('sl listingblock').titled(u'Listing').within(self.portal))
+        create(Builder('sl content page').titled(u'SubPage').within(self.portal))
+
+        component = getAdapter(self.portal, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+
+        self.assertIn('textblock', self.portal.objectIds())
+        self.assertIn('listing', self.portal.objectIds())
+        self.assertIn('subpage', self.portal.objectIds())
+
+        component.setData([u'staticuid00000000000000000000001'], {})
+
+        self.assertIn('textblock', self.portal.objectIds())
+        self.assertNotIn('listing', self.portal.objectIds())
+        self.assertIn('subpage', self.portal.objectIds())
+
+    @staticuid('staticuid')
+    def test_getter_on_textblock_returns_empyt_list(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        block = create(Builder('sl textblock').titled(u'TextBlock').within(page))
+
+        component = getAdapter(block, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+        self.assertEquals([],
+                          json.loads(json.dumps(component.getData())))
+
+    @staticuid('staticuid')
+    def test_setter_on_textblock_does_not_break(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        block = create(Builder('sl textblock').titled(u'TextBlock').within(page))
+
+        component = getAdapter(block, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+        component.setData([], {})
+
+    @staticuid('staticuid')
+    def test_getter_on_folderish_block_returns_children_uuids(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        listing = create(Builder('sl listingblock').titled(u'Listing').within(page))
+        create(Builder('file').titled(u'Foo').within(listing))
+        create(Builder('file').titled(u'Bar').within(listing))
+
+        component = getAdapter(listing, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+        self.assertEquals([u'staticuid00000000000000000000003',
+                           u'staticuid00000000000000000000004'],
+                          json.loads(json.dumps(component.getData())))
+
+    @staticuid('staticuid')
+    def test_setter_on_folderish_block_removes_all_childrens_which_are_not_listed(self):
+        page = create(Builder('sl content page').titled(u'Page'))
+        listing = create(Builder('sl listingblock').titled(u'Listing').within(page))
+        create(Builder('file').titled(u'Foo').within(listing))
+        create(Builder('file').titled(u'Bar').within(listing))
+
+        component = getAdapter(listing, IDataCollector,
+                               name='ftw.simplelayout:RemoveDeletedSLContentishChildren')
+
+        self.assertEquals(['foo', 'bar'], listing.objectIds())
+        component.setData([u'staticuid00000000000000000000003'], {})
+        self.assertEquals(['foo'], listing.objectIds())


### PR DESCRIPTION
:construction: based on https://github.com/4teamwork/ftw.publisher.core/pull/26

When publishing dexterity objects where the description was not set, the
description may be str instead of unicode because of a bad default.

https://github.com/plone/plone.dexterity/pull/33
https://github.com/plone/plone.dexterity/pull/35

We change empty str descriptions to empyt unicodes for preventing this error.


