### PR TITLE
Add data collector for ftw.servicenavigation data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add data collector for ftw.servicenavigation data. [jone]
 
 
 2.6.0 (2015-12-23)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -170,4 +170,21 @@
             name="ftw.simplelayout:RemoveDeletedSLContentishChildren" />
     </configure>
 
+    <!-- ftw.servicenavigation -->
+    <configure zcml:condition="installed ftw.servicenavigation">
+        <adapter
+            for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".ftw_servicenavigation.ServiceNavigationDataCollector"
+            name="ftw.servicenavigation" />
+
+        <!-- ftw.servicenavigation + ftw.subsite -->
+        <adapter
+            zcml:condition="installed ftw.subsite"
+            for="ftw.subsite.interfaces.ISubsite"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".ftw_servicenavigation.ServiceNavigationDataCollector"
+            name="ftw.servicenavigation" />
+    </configure>
+
 </configure>

--- a/ftw/publisher/core/adapters/ftw_servicenavigation.py
+++ b/ftw/publisher/core/adapters/ftw_servicenavigation.py
@@ -1,0 +1,20 @@
+from AccessControl.SecurityInfo import ClassSecurityInformation
+from ftw.servicenavigation.form import ANNOTATION_KEY
+from zope.annotation import IAnnotations
+
+
+class ServiceNavigationDataCollector(object):
+    security = ClassSecurityInformation()
+
+    def __init__(self, context):
+        self.context = context
+
+    security.declarePrivate('getData')
+    def getData(self):
+        annotations = IAnnotations(self.context)
+        return annotations.get(ANNOTATION_KEY, {})
+
+    security.declarePrivate('setData')
+    def setData(self, data, metadata=None):
+        annotations = IAnnotations(self.context)
+        annotations[ANNOTATION_KEY] = data

--- a/ftw/publisher/core/tests/test_ftw_servicenavigation.py
+++ b/ftw/publisher/core/tests/test_ftw_servicenavigation.py
@@ -1,0 +1,60 @@
+from ftw.publisher.core.adapters.ftw_servicenavigation import ANNOTATION_KEY
+from ftw.publisher.core.interfaces import IDataCollector
+from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
+from ftw.publisher.core.utils import decode_for_json
+from ftw.publisher.core.utils import encode_after_json
+from persistent import Persistent
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+from unittest2 import TestCase
+from zope.annotation import IAnnotations
+from zope.component import getAdapter
+
+
+EXAMPLE_DATA = PersistentMapping({
+    'links': PersistentList([
+        PersistentMapping({'internal_link': None,
+                           'label': u'External Link',
+                           'icon': 'heart',
+                           'external_url': 'http://www.4teamwork.ch'}),
+
+        PersistentMapping({'internal_link': '/a-page',
+                           'label': u'Internal Link',
+                           'icon': 'glass',
+                           'external_url': None})])})
+
+
+class TestServiceNavigation(TestCase):
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def test_getData_extracts_data(self):
+        annotations = IAnnotations(self.layer['portal'])
+        annotations[ANNOTATION_KEY] = EXAMPLE_DATA
+
+        component = getAdapter(self.layer['portal'], IDataCollector,
+                               name='ftw.servicenavigation')
+        self.assertEqual(EXAMPLE_DATA, component.getData())
+
+    def test_setData_stores_data(self):
+        annotations = IAnnotations(self.layer['portal'])
+        self.assertIsNone(annotations.get(ANNOTATION_KEY))
+
+        component = getAdapter(self.layer['portal'], IDataCollector,
+                               name='ftw.servicenavigation')
+        component.setData(EXAMPLE_DATA)
+        self.assertEqual(EXAMPLE_DATA, annotations[ANNOTATION_KEY])
+
+    def test_roundtrip_stores_data_persistently(self):
+        annotations = IAnnotations(self.layer['portal'])
+        component = getAdapter(self.layer['portal'], IDataCollector,
+                               name='ftw.servicenavigation')
+
+        annotations[ANNOTATION_KEY] = EXAMPLE_DATA
+        wired_data = decode_for_json(component.getData())
+        del annotations[ANNOTATION_KEY]
+
+        component.setData(encode_after_json(wired_data))
+        data = annotations[ANNOTATION_KEY]
+        self.assertEqual(EXAMPLE_DATA, data)
+        self.assertIsInstance(data, Persistent)
+        self.assertIsInstance(data['links'], Persistent)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ extras_require['tests'] = tests_require = [
     'ftw.builder',
     'ftw.contentpage',
     'ftw.shop',
+    'ftw.servicenavigation',
     'ftw.simplelayout [contenttypes]',
     'ftw.testing',
     'plone.app.blob',

--- a/sources.cfg
+++ b/sources.cfg
@@ -3,3 +3,5 @@ extends = http://plonesource.org/sources.cfg
 extensions = mr.developer
 
 auto-checkout =
+# wait for release
+    ftw.servicenavigation


### PR DESCRIPTION
The ftw.servicenavigation data collector sends the data of ftw.servicenavigation stored in the annotation of the Plone site root and of ftw.subsites.