### PR TITLE
Fix error when publishing DX relation with no target.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix error when publishing DX relation with no target. [jone]
 
 
 2.7.0 (2016-03-30)

--- a/ftw/publisher/core/adapters/dx_field_data.py
+++ b/ftw/publisher/core/adapters/dx_field_data.py
@@ -176,7 +176,7 @@ class DexterityFieldData(object):
             return ['raw', None]
 
         if isinstance(value, RelationValue):
-            if value.isBroken():
+            if value.isBroken() or not value.to_path:
                 return ['raw', None]
 
             return ['RelationValue',


### PR DESCRIPTION
There are sometimes situations where dxterity relations has no
to-path. In this case the relation is broken and we cannot publish it,
so we just remove it.

/cc @maethu 