### PR TITLE
Fix plone.app.event timezone problems.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.7.4 (unreleased)
 ------------------
 
+- Fix plone.app.event timezone problems. [jone]
+
 - Support timezones. [jone]
 
 

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -202,4 +202,13 @@
             name="ftw.servicenavigation" />
     </configure>
 
+    <!-- plone.app.event 1.1.x -->
+    <configure zcml:condition="installed plone.app.event">
+        <adapter
+            for="plone.app.event.dx.interfaces.IDXEvent"
+            provides="ftw.publisher.core.interfaces.IDataCollector"
+            factory=".plone_app_event.FixEventTimezones"
+            name="zzz_plone_app_event_fix_timezones" />
+    </configure>
+
 </configure>

--- a/ftw/publisher/core/adapters/plone_app_event.py
+++ b/ftw/publisher/core/adapters/plone_app_event.py
@@ -1,0 +1,27 @@
+from AccessControl.SecurityInfo import ClassSecurityInformation
+from plone.app.event.dx.behaviors import data_postprocessing
+
+
+class FixEventTimezones(object):
+    """
+    plone.app.event's IEventBasic stores temporarily FakeZone objects
+    as tzinfo of start and end dates.
+    This is cleaned up by data_postprocessing when the modification event is fired.
+    But the publisher does not fire the modification event.
+    Because we do not want to have side effects by introducing firing the modification
+    event we trigger the post processing manually.
+
+    The data collector adapters are executed in order of their names.
+    This adapter should be executed after the dx_field_data_adapter, so we prefix
+    the name of the adapter with zzz_.
+    """
+    security = ClassSecurityInformation()
+
+    def __init__(self, context):
+        self.context = context
+
+    def getData(self):
+        return None
+
+    def setData(self, data, metadata):
+        data_postprocessing(self.context, None)


### PR DESCRIPTION
plone.app.event has a special handling for timezones: it uses fake time zones which are replaced when the modified event is triggered. The publisher does not trigger the modified event, so we need to call the cleanup function manually.