### PR TITLE
Backreferences: awoid error with broken references

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Backreferences: awoid error with broken references. [jone]
 
 
 2.8.0 (2016-11-08)

--- a/ftw/publisher/core/adapters/backreferences.py
+++ b/ftw/publisher/core/adapters/backreferences.py
@@ -65,6 +65,9 @@ class Backreferences(object):
         for ref in references:
             # get source object
             src = ref.getSourceObject()
+            if src is None:
+                continue
+
             suid = src.UID()
 
             if suid not in data.keys():


### PR DESCRIPTION
When there are broken back references we should ignore them. This makes back references extraction more robust.

Fixes https://github.com/4teamwork/ftw.publisher.sender/issues/39