### PR TITLE
Awoid duplicate relations in catalog when republishing.

### DIFF
--- a/ftw/publisher/core/adapters/dx_field_data.py
+++ b/ftw/publisher/core/adapters/dx_field_data.py
@@ -22,7 +22,7 @@ except pkg_resources.DistributionNotFound:
 else:
     HAS_RELATIONS = True
     from z3c.relationfield import RelationValue
-    from z3c.relationfield.event import addRelations
+    from z3c.relationfield.event import updateRelations
     from z3c.relationfield.interfaces import IRelation
     from z3c.relationfield.interfaces import IRelationChoice
     from z3c.relationfield.interfaces import IRelationList
@@ -92,7 +92,7 @@ class DexterityFieldData(object):
                 setattr(repr, name, value)
 
         if HAS_RELATIONS:
-            addRelations(self.context, None)
+            updateRelations(self.context, None)
 
     def pack(self, name, field, value):
         """Packs the field data and makes it ready for transportation with

--- a/ftw/publisher/core/tests/test_dexterity.py
+++ b/ftw/publisher/core/tests/test_dexterity.py
@@ -5,7 +5,6 @@ from ftw.publisher.core.testing import PUBLISHER_EXAMPLE_CONTENT_FIXTURE
 from ftw.publisher.core.tests.interfaces import ITextSchema
 from json import dumps
 from json import loads
-from plone import api
 from plone.app.relationfield.behavior import IRelatedItems
 from plone.app.testing import applyProfile
 from plone.app.testing import IntegrationTesting
@@ -170,6 +169,10 @@ class TestDexterityFieldData(TestCase):
         self._set_field_data(target, data, json=True)
         self.assertEquals(1, len(target.relatedItems),
                           'Relation missing')
+
+        self._set_field_data(target, data, json=True)
+        self.assertEquals(1, len(target.relatedItems),
+                          'Publishing twice should not add more relations.')
 
         relation, = target.relatedItems
         self.assertEquals(foo, relation.to_object)


### PR DESCRIPTION
When an object is published for the second time, having the same relation, it should not be readded to the relation catalog but updated instead.
By using ``updateRelations`` instead of ``addRelations`` this is handled correctly by ``z3c.relationfield``.