### PR TITLE
Improve publishing the layout property on plone site root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Improve publishing the layout property on plone site
+  root (introduced in 2.7.3). [mbaechtold]
 
 
 2.9.1 (2017-02-28)

--- a/ftw/publisher/core/adapters/properties_data.py
+++ b/ftw/publisher/core/adapters/properties_data.py
@@ -98,7 +98,7 @@ class PropertiesData(object):
 
         if not IPloneSiteRoot.providedBy(self.object):
             self.object.manage_delProperties(propertiesToDelete)
-        else:
+        elif 'layout' in currentProperties:
             # Delete layout property anyway - this supports removing the prop.
             self.object.manage_delProperties(['layout', ])
 

--- a/ftw/publisher/core/tests/test_properties_adapter.py
+++ b/ftw/publisher/core/tests/test_properties_adapter.py
@@ -98,3 +98,27 @@ class TestPortletAdapter(TestCase):
 
         # Other properties should be untouched
         self.assertEqual(cached_title, portal.Title())
+
+    def test_remove_non_existing_layout_property_on_root(self):
+        """
+        Removing an non existing layout property on the plone site root
+        must not fail.
+        """
+        portal = self.layer['portal']
+        portal.setLayout('folder_contents')
+        portal.manage_delProperties(['layout', ])
+        adapter = getAdapter(portal, IDataCollector,
+                             name="properties_data_adapter")
+
+        data = adapter.getData()
+        self.assertFalse(data, 'Expect an empty list')
+
+        cached_title = portal.Title()
+        adapter.setData(data, {})
+
+        self.assertNotIn('layout',
+                         portal.propertyIds(),
+                         'Property layout should be removed')
+
+        # Other properties should be untouched
+        self.assertEqual(cached_title, portal.Title())


### PR DESCRIPTION
Publishing the layout property on plone site root has been introduced in 2.7.3 but used to fail if the plone site root on the receiving end does not have the layout property.

We must therefor check if the property is available before trying to delete it in order to prevent the following error raised in `manage_delProperties()`: BadRequest: The property <em>layout</em> does not exist.