### PR TITLE
Fix tests by no longer installing the "splinter" extra.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.9.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer install "splinter" extra from "ftw.testing". [mbaechtold]
 
 
 2.9.2 (2017-06-12)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require['tests'] = tests_require = [
     'ftw.servicenavigation',
     'ftw.shop',
     'ftw.simplelayout [contenttypes]',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'plone.app.blob',
     'plone.app.relationfield',
     'plone.app.testing',


### PR DESCRIPTION
The "splinter" extra has been removed from "ftw.testing". Use "ftw.testbrowser" instead!

See https://ci.4teamwork.ch/builds/92634/tasks/135499