### PR TITLE
Implement relations values for nested structures

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.9.3 (unreleased)
 ------------------
 
+- Support datagrid GridRow serialization/deserialization of RelationValues [mathias.leimgruber]
 - No longer install "splinter" extra from "ftw.testing". [mbaechtold]
 
 

--- a/ftw/publisher/core/testing.py
+++ b/ftw/publisher/core/testing.py
@@ -12,17 +12,21 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from plone.dexterity.content import Container
 from plone.portlet.collection import collection
 from plone.portlet.static import static
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
+from plone.supermodel import model
 from plone.testing import z2
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.configuration import xmlconfig
 from zope.interface import alsoProvides
+from zope.interface import implements
 from zope.interface import Interface
 import ftw.contentpage.tests.builders
+import ftw.publisher.core.tests.builders
 import ftw.shop.tests.builders
 import ftw.simplelayout.tests.builders
 import pkg_resources
@@ -46,6 +50,17 @@ class IDummyIface2(Interface):
 
 class IDummyIface3(Interface):
     """This is a dummy interface"""
+
+class ISampleContentSchema(model.Schema):
+    pass
+
+
+class ISampleContententMarker(Interface):
+    pass
+
+
+class SampleContent(Container):
+    implements(ISampleContententMarker)
 
 
 class ZCMLLayer(ComponentRegistryLayer):
@@ -73,6 +88,7 @@ class PublisherCoreLayer(PloneSandboxLayer):
             '  <include package="z3c.autoinclude" file="meta.zcml" />'
             '  <includePlugins package="plone" />'
             '  <includePluginsOverrides package="plone" />'
+            '  <include package="ftw.publisher.core.tests" file="behaviors.zcml" />'
             '</configure>',
             context=configurationContext)
 
@@ -90,6 +106,7 @@ class PublisherCoreLayer(PloneSandboxLayer):
         applyProfile(portal, 'ftw.simplelayout.contenttypes:default')
         applyProfile(portal, 'ftw.contentpage:default')
         applyProfile(portal, 'ftw.shop:default')
+        applyProfile(portal, 'collective.z3cform.datagridfield:default')
 
 
 PUBLISHER_CORE_FIXTURE = PublisherCoreLayer()

--- a/ftw/publisher/core/tests/behaviors.py
+++ b/ftw/publisher/core/tests/behaviors.py
@@ -1,0 +1,41 @@
+from collective.z3cform.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield import DictRow
+from ftw.referencewidget.sources import ReferenceObjSourceBinder
+from ftw.referencewidget.widget import ReferenceWidgetFactory
+from plone.autoform import directives
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.directives import form
+from plone.supermodel import model
+from z3c.relationfield.schema import RelationChoice
+from zope import schema
+from zope.interface import alsoProvides
+from zope.interface import Interface
+
+
+class IDataGridRow(model.Schema):
+    label = schema.TextLine(
+        title=u'Label',
+        default=u'I am the default label',
+    )
+
+    directives.widget(link=ReferenceWidgetFactory)
+    link = RelationChoice(
+        title=u'Link',
+        source=ReferenceObjSourceBinder(),
+        required=False,
+    )
+
+
+class IDataGridFieldExample(Interface):
+    """Demo behavior containing a DataGridField.
+    """
+    form.widget('the_data_grid', DataGridFieldFactory, allow_reorder=True)
+    the_data_grid = schema.List(
+        title=u'The Data Grid',
+        value_type=DictRow(title=u'the_data_grid_row', schema=IDataGridRow),
+        required=False,
+        missing_value=[],
+    )
+
+
+alsoProvides(IDataGridFieldExample, IFormFieldProvider)

--- a/ftw/publisher/core/tests/behaviors.zcml
+++ b/ftw/publisher/core/tests/behaviors.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone">
+
+    <!-- Register behaviors for testing -->
+    <plone:behavior
+        title="Data grid field demo behavior"
+        description="Adds the ability to a data grid rows"
+        provides=".behaviors.IDataGridFieldExample"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
+</configure>

--- a/ftw/publisher/core/tests/builders.py
+++ b/ftw/publisher/core/tests/builders.py
@@ -1,0 +1,9 @@
+from ftw.builder import registry
+from ftw.builder.dexterity import DexterityBuilder
+
+
+class SampleContentBuilder(DexterityBuilder):
+    portal_type = 'SampleContent'
+
+registry.builder_registry.register(
+    'datagrid sample content', SampleContentBuilder)

--- a/ftw/publisher/core/tests/test_datagrid_with_relations.py
+++ b/ftw/publisher/core/tests/test_datagrid_with_relations.py
@@ -1,0 +1,74 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.publisher.core import utils
+from ftw.publisher.core.interfaces import IDataCollector
+from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
+from ftw.publisher.core.tests.behaviors import IDataGridFieldExample
+from ftw.publisher.core.utils import create_relation_for
+from json import dumps
+from json import loads
+from plone.dexterity.fti import DexterityFTI
+from unittest2 import TestCase
+from zope.component import getAdapter
+
+
+class TestDataGridRelationsAdapter(TestCase):
+
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(TestDataGridRelationsAdapter, self).setUp()
+        self.setup_sample_fti()
+
+        self.content_a = create(Builder('datagrid sample content')
+                                .titled(u'refwidget sample content A'))
+        self.content_b = create(Builder('datagrid sample content')
+                                .titled(u'refwidget sample content B'))
+
+        payload = [{'label': 'First row',
+                    'link': create_relation_for(self.content_b)}]
+        IDataGridFieldExample(self.content_a).the_data_grid = payload
+
+    def setup_sample_fti(self):
+        types_tool = self.layer['portal'].portal_types
+
+        default_behaviors = [
+            'plone.app.dexterity.behaviors.metadata.IBasic',
+            'plone.app.content.interfaces.INameFromTitle',
+            IDataGridFieldExample.__identifier__
+        ]
+
+        fti = DexterityFTI('SampleContent')
+        fti.schema = 'ftw.publisher.core.testing.ISampleContentSchema'
+        fti.klass = 'ftw.publisher.core.testing.SampleContent'
+        fti.behaviors = tuple(default_behaviors)
+        fti.default_view = 'view'
+        types_tool._setObject('SampleContent', fti)
+
+    def _get_collector_for(self, obj):
+        return getAdapter(obj, IDataCollector,
+                          name='dx_field_data_adapter')
+
+    def _get_field_data(self, obj):
+        collector = self._get_collector_for(obj)
+        data = collector.getData()
+        data = utils.decode_for_json(data)
+        data = dumps(data)
+        return data
+
+    def _set_field_data(self, obj, data):
+        collector = self._get_collector_for(obj)
+        data = loads(data)
+        data = utils.encode_after_json(data)
+        return collector.setData(data, {})
+
+    def test_extract_and_set_relation_value_in_datagrid(self):
+        target = create(Builder('datagrid sample content')
+                        .titled(u'target'))
+
+        data = self._get_field_data(self.content_a)
+        self._set_field_data(target, data)
+
+        self.assertEquals(
+            self.content_b,
+            target.the_data_grid[0]['link'].to_object)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extras_require['tests'] = tests_require = [
     'collective.geo.contentlocations',
     'collective.geo.geographer',
     'collective.testcaselayer',
+    'collective.z3cform.datagridfield',
     'ftw.builder',
     'ftw.contentpage',
     'ftw.servicenavigation',


### PR DESCRIPTION
This implicitly supports RelationValues for datagrid fields, since they store list of dicts.