### PR TITLE
Add conterpart method to make_path_relative to make relative path absolute again

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add utils function to make a relative path absolute. [raphael-s]
 
 
 2.10.0 (2017-11-14)

--- a/ftw/publisher/core/tests/test_utils.py
+++ b/ftw/publisher/core/tests/test_utils.py
@@ -188,6 +188,16 @@ class TestPathFunctions(TestCase):
             'the-folder/the-page',
             utils.make_path_relative('/plone/the-folder/the-page'))
 
+    def test_make_path_absolute(self):
+        self.assertEquals(
+            '/plone/the-folder/the-page',
+            utils.make_path_absolute('the-folder/the-page'))
+
+    def test_make_path_absolute_removes_extra_slash(self):
+        self.assertEquals(
+            '/plone/the-folder/the-page',
+            utils.make_path_absolute('/the-folder/the-page'))
+
     def test_get_relative_path(self):
         folder = create(Builder('folder').titled('The Folder'))
         page = create(Builder('page').titled('The Page').within(folder))

--- a/ftw/publisher/core/utils.py
+++ b/ftw/publisher/core/utils.py
@@ -334,6 +334,13 @@ def make_path_relative(path):
     return path[len(site_path + '/'):]
 
 
+def make_path_absolute(path):
+    """Make a relative path absolute by adding the site root.
+    """
+    site_path = '/'.join(getSite().getPhysicalPath())
+    return '/'.join([site_path, path.lstrip('/')])
+
+
 def get_relative_path(obj):
     """Returns the path to an object relative to the site root.
     """


### PR DESCRIPTION
Add method `make_path_absolute` to provide a util to make a path absolute again by joining it onto the site root path.
This method is the counterpart to `make_path_relative`.

