### PR TITLE
Pin down c.z.datagridfield for Plone 4 tests:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ extras_require = {
         ],
     'tests_plone4': [
         'collective.geo.contentlocations',
+        'collective.z3cform.datagridfield < 1.4.0',
         'ftw.contentpage',
         'ftw.shop',
         'simplelayout.base',


### PR DESCRIPTION
Fix tests by pinning down `collective.z3cform.datagridfield` to a Plone 4 compatible version for the `tests_plone4` extra.

(Plone 4 support got [dropped in `1.4.0`](https://github.com/collective/collective.z3cform.datagridfield/blob/master/CHANGES.rst#140-2019-02-21), which now contains a hard dependency on Plone 5.)

Fixes this failure: https://ci.4teamwork.ch/builds/228428/tasks/375188

A similar fix would solve this issue for `ftw.publisher.sender` (it would probably make sense to require `ftw.publisher.core[tests_plone4]` in the `ftw.publisher.sender[tests_plone4]` extra, no?) - but there's still other test failures cropping up in `.sender` (failing assertions, simplelayout related).
