### PR TITLE
ftw.trash support für ftw.simplelayout content

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -3,6 +3,3 @@ extends =
     test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
-[instance]
-eggs +=
-    ftw.publisher.core [development]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for ftw.trash with simplelayout [mathias.leimgruber]
 
 
 2.11.0 (2019-03-29)

--- a/ftw/publisher/core/adapters/simplelayout_utils.py
+++ b/ftw/publisher/core/adapters/simplelayout_utils.py
@@ -37,6 +37,14 @@ except pkg_resources.DistributionNotFound:
     pass
 
 
+try:
+    pkg_resources.get_distribution('ftw.trash')
+    from ftw.trash.interfaces import ITrashed
+    HAS_FTW_TRASH = True
+except pkg_resources.DistributionNotFound:
+    HAS_FTW_TRASH = False
+
+
 marker = object()
 
 
@@ -60,6 +68,9 @@ def is_sl_contentish(context):
     """
     if IPloneSiteRoot.providedBy(context):
         # Abort recursion when site root reached.
+        return False
+
+    if HAS_FTW_TRASH and ITrashed.providedBy(context):
         return False
 
     if filter(lambda x, c=context: x.providedBy(c), sl_pages):

--- a/ftw/publisher/core/tests/test_ftw_simplelayout_adapters.py
+++ b/ftw/publisher/core/tests/test_ftw_simplelayout_adapters.py
@@ -10,6 +10,7 @@ from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IBlockProperties
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.testing import staticuid
+from ftw.trash.trasher import Trasher
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.uuid.interfaces import IUUID
@@ -21,7 +22,6 @@ from zope.component import queryMultiAdapter
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserView
 import json
-
 
 
 class TestSimplelayoutContentish(TestCase):
@@ -42,6 +42,13 @@ class TestSimplelayoutContentish(TestCase):
         block = create(Builder('sl textblock')
                        .within(create(Builder('sl content page'))))
         self.assertTrue(is_sl_contentish(block))
+
+    def test_trashed_textblock_is_not_sl_contentish(self):
+        block = create(Builder('sl textblock')
+                       .within(create(Builder('sl content page'))))
+        trasher = Trasher(block)
+        trasher.trash()
+        self.assertFalse(is_sl_contentish(block))
 
     def test_textblock_with_workflow_is_not_contentish(self):
         wftool = getToolByName(self.portal, 'portal_workflow')

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require['tests'] = tests_require = [
     'collective.z3cform.datagridfield',
     'ftw.builder',
     'ftw.servicenavigation',
-    'ftw.simplelayout [contenttypes]',
+    'ftw.simplelayout [contenttypes, trash]',
     'ftw.testing',
     'plone.app.blob',
     'plone.app.contenttypes',


### PR DESCRIPTION
`is_sl_contentish` now also returns `false` if the content is trashed by ftw.trash. 

