### PR TITLE
Fix publishing of types with IShortName behaviour

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Use plone.app.uuid to resolve uuids to support plone 5 [Nachtalb]
+- Fix publishing of types with IShortName behaviour [Nachtalb]
 
 
 2.12.0 (2019-10-18)

--- a/ftw/publisher/core/adapters/dx_field_data.py
+++ b/ftw/publisher/core/adapters/dx_field_data.py
@@ -12,6 +12,12 @@ import base64
 import DateTime
 import pkg_resources
 
+try:
+    # Since plone.app.dexterity 2.1.0
+    from plone.app.dexterity.behaviors.id import IShortName
+    HAS_ISHORT = True
+except ImportError:
+    HAS_ISHORT = False
 
 try:
     pkg_resources.get_distribution('z3c.relationfield')
@@ -56,6 +62,9 @@ class DexterityFieldData(object):
         data = {}
 
         for schemata in iterSchemata(self.context):
+            if HAS_ISHORT and schemata == IShortName:
+                continue
+
             subdata = {}
             repr = schemata(self.context)
             for name, field in schema.getFieldsInOrder(schemata):


### PR DESCRIPTION
The default plone types implement the IShortName behaviour which when
applying on the receiver side wants to rename the existing object to the
same name it already has. But because it already has that name it
appends a -1 and the rest of the publishing fails.