### PR TITLE
Fix bug when deleting children without ftw.trash installed

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-5.1.x.cfg
+    test-plone-5.1.x-trash.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix bug when deleting children without ``ftw.trash`` installed. [jone]
 
 
 2.13.0 (2019-11-26)

--- a/ftw/publisher/core/adapters/children.py
+++ b/ftw/publisher/core/adapters/children.py
@@ -31,4 +31,4 @@ class RemoveChildren(object):
             # When ftw.trash is installed, immediately delete the working copy.
             self.context.manage_immediatelyDeleteObjects(ids_to_delete)
         else:
-            self.context.working_copy.manage_delObjects(ids_to_delete)
+            self.context.manage_delObjects(ids_to_delete)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require['tests'] = tests_require = [
     'collective.z3cform.datagridfield',
     'ftw.builder',
     'ftw.servicenavigation',
-    'ftw.simplelayout [contenttypes, trash]',
+    'ftw.simplelayout [contenttypes]',
     'ftw.testing',
     'plone.app.blob',
     'plone.app.contenttypes',

--- a/test-plone-4.3.x-trash.cfg
+++ b/test-plone-4.3.x-trash.cfg
@@ -1,0 +1,17 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    sources.cfg
+
+package-name = ftw.publisher.core
+
+
+[test]
+eggs +=
+    plonetheme.onegov
+    ftw.publisher.core[tests_plone4]
+    ftw.trash
+
+[versions]
+# Products.PloneFormGen >= 1.8 is incompatible with Plone <= 5.x
+Products.PloneFormGen = 1.7.12

--- a/test-plone-5.1.x-trash.cfg
+++ b/test-plone-5.1.x-trash.cfg
@@ -1,0 +1,11 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+    sources.cfg
+
+package-name = ftw.publisher.core
+
+
+[test]
+eggs +=
+    ftw.trash


### PR DESCRIPTION
#### Problem

```python
Traceback (most recent call last):
  File "/home/zope/eggs/ftw.publisher.receiver-2.2.1-py2.7.egg/ftw/publisher/receiver/browser/views.py", line 39, in __call__
    state = self.handleRequest()
  File "/home/zope/eggs/ftw.publisher.receiver-2.2.1-py2.7.egg/ftw/publisher/receiver/browser/views.py", line 90, in handleRequest
    return self.pushAction(metadata, self.data)
  File "/home/zope/eggs/ftw.publisher.receiver-2.2.1-py2.7.egg/ftw/publisher/receiver/browser/views.py", line 275, in pushAction
    adapter.setData(data[name], metadata)
  File "/home/zope/eggs/ftw.publisher.core-2.12.0-py2.7.egg/ftw/publisher/core/adapters/children.py", line 34, in setData
    self.context.working_copy.manage_delObjects(ids_to_delete)
AttributeError: working_copy
```

#### Cause

The problem occurs when publishing a page and the frontend does not have `ftw.trash` installed (which is the standard setup).

Problem:
```diff
- self.context.working_copy.manage_delObjects
+ self.context.manage_delObjects
```

The `.working_copy` does not belong there and was probably copy/pasted by me without noticing.

#### Testing

We didn't catch this problem in testing because the tests were run always with `ftw.trash` installed, which goes into a different branch in the `if`-clause.

-> I have duplicated the test setup to also test without `ftw.trash`.