### PR TITLE
Disable plone.app.event fix for Plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.13.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Disable plone.app.event fix for Plone 5. [jone]
 
 
 2.13.1 (2019-11-29)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -177,11 +177,13 @@
 
     <!-- plone.app.event 1.1.x -->
     <configure zcml:condition="installed plone.app.event">
+      <configure zcml:condition="not-have plone-5">
         <adapter
             for="plone.app.event.dx.interfaces.IDXEvent"
             provides="ftw.publisher.core.interfaces.IDataCollector"
             factory=".plone_app_event.FixEventTimezones"
             name="zzz_plone_app_event_fix_timezones" />
+      </configure>
     </configure>
 
 </configure>


### PR DESCRIPTION
In Plone 4, plone.app.event used to separate the timezone info from the dates, which made it necessary to have a custom publisher adapter for fixing the start and end values.

In Plone 5, plone.app.event has a different implementation which breaks when the fix is used because the fix uses Zope DateTime which is no longer wise.

The problem was that the receiver side has stored `GMT+1` as timezone, which is not a valid `pytz` timezone, causing errors such as:
```
UnknownTimeZoneError: (UnknownTimeZoneError('GMT+1',), <function _p at 0x7fa70a7d4f50>, ('GMT+1',))
```