### PR TITLE
Add function to get parent belonging to child

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Fix Plone4 test setup [Nachtalb]
+- Add API endpoint to get parent belonging to child (recursively) [Nachtalb]
 
 
 2.13.2 (2020-01-15)

--- a/ftw/publisher/core/belongs_to_parent.py
+++ b/ftw/publisher/core/belongs_to_parent.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_chain
+from Acquisition import aq_inner
 from Products.CMFCore.utils import getToolByName
 from zope.dottedname.resolve import resolve
 import pkg_resources
@@ -52,3 +54,9 @@ def belongs_to_parent(context):
         return False
 
     return True
+
+
+def get_main_obj_belonging_to(obj):
+    for obj_or_parent in aq_chain(aq_inner(obj)):
+        if not belongs_to_parent(obj_or_parent):
+            return obj_or_parent

--- a/ftw/publisher/core/tests/test_belongs_to_parent.py
+++ b/ftw/publisher/core/tests/test_belongs_to_parent.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.publisher.core import belongs_to_parent
+from ftw.publisher.core.belongs_to_parent import get_main_obj_belonging_to
 from ftw.publisher.core.tests import IntegrationTestCase
 from ftw.publisher.core.utils import IS_PLONE_5
 from Products.CMFCore.utils import getToolByName
@@ -20,6 +21,11 @@ class TestBelongsToParent(IntegrationTestCase):
         self.set_workflow(Folder=None)
         self.assertFalse(belongs_to_parent(create(Builder('folder'))))
 
+    def test_folders_main_object_is_itself(self):
+        self.set_workflow(Folder=None)
+        folder = create(Builder('folder'))
+        self.assertEquals(get_main_obj_belonging_to(folder), folder)
+
 
 class TestFTWSimplelayoutBelongsToParent(IntegrationTestCase):
 
@@ -29,6 +35,13 @@ class TestFTWSimplelayoutBelongsToParent(IntegrationTestCase):
         self.set_workflow({'ftw.simplelayout.ContentPage': 'simple_publication_workflow',
                            'ftw.simplelayout.TextBlock': None,
                            'File': None})
+
+    def test_textblocks_main_obj_is_parent(self):
+        self.set_workflow(Folder=None)
+        page = create(Builder('sl content page'))
+        textblock = create(Builder('sl textblock').within(page))
+
+        self.assertEquals(get_main_obj_belonging_to(textblock), page)
 
     def test_content_page_does_not_belong_to_parent(self):
         page = create(Builder('sl content page').titled(u'The Page'))


### PR DESCRIPTION
This function is used in ftw.publisher.sender https://github.com/4teamwork/ftw.publisher.sender/pull/73 but belongs to the belongs_to_parent like functions, thus we add and test it in here.

❗️ Based on https://github.com/4teamwork/ftw.publisher.core/pull/64 to fix tests. Update base branch before merging. 