### PR TITLE
Fix plone4 test setup

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix Plone4 test setup [Nachtalb]
 
 
 2.13.2 (2020-01-15)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extras_require = {
         'collective.geo.contentlocations',
         'collective.z3cform.datagridfield < 1.4.0',
         'ftw.shop',
+        'plonetheme.onegov < 4.0.0'
     ]
 }
 

--- a/test-plone-4.3.x-trash.cfg
+++ b/test-plone-4.3.x-trash.cfg
@@ -8,7 +8,6 @@ package-name = ftw.publisher.core
 
 [test]
 eggs +=
-    plonetheme.onegov
     ftw.publisher.core[tests_plone4]
     ftw.trash
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,7 +8,6 @@ package-name = ftw.publisher.core
 
 [test]
 eggs +=
-    plonetheme.onegov
     ftw.publisher.core[tests_plone4]
 
 [versions]


### PR DESCRIPTION
plonetheme.onegov 4.x drops Plone 4.3 compatibility so we need an
earlier version.