### PR TITLE
"_order" Attribute on portlet manager needs to be a persistent list

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- "_order" Attribute on portlet manager needs to be a persistent list. [mathias.leimgruber]
 
 
 2.14.0 (2020-01-31)

--- a/ftw/publisher/core/adapters/portlet_data.py
+++ b/ftw/publisher/core/adapters/portlet_data.py
@@ -2,6 +2,7 @@ from AccessControl.SecurityInfo import ClassSecurityInformation
 from ftw.publisher.core import getLogger
 from ftw.publisher.core.interfaces import IDataCollector
 from OFS.Image import Image as OFSImage
+from persistent.list import PersistentList
 from plone.portlets.constants import CONTENT_TYPE_CATEGORY, CONTEXT_CATEGORY
 from plone.portlets.constants import USER_CATEGORY, GROUP_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
@@ -248,4 +249,4 @@ class PortletsData(object):
                 IPortletAssignmentSettings(portlet_assignment).data = settings
 
             # set new order afterwards
-            portlets._order = order
+            portlets._order = PersistentList(order)

--- a/ftw/publisher/core/tests/test_portlet_adapter.py
+++ b/ftw/publisher/core/tests/test_portlet_adapter.py
@@ -3,6 +3,7 @@ from ftw.publisher.core import utils
 from ftw.publisher.core.interfaces import IDataCollector
 from ftw.publisher.core.testing import PUBLISHER_EXAMPLE_CONTENT_INTEGRATION
 from ftw.publisher.core.utils import IS_PLONE_5
+from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone.portlet.static import static
 from plone.portlets.constants import ASSIGNMENT_SETTINGS_KEY
@@ -17,7 +18,6 @@ from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 import json
-
 
 
 class TestPortletAdapter(TestCase):
@@ -256,6 +256,21 @@ class TestPortletAdapter(TestCase):
         self.assertEqual(
             settings,
             IPortletAssignmentSettings(new_assignment).data)
+
+    def test_order_attr_is_persitence_list(self):
+        #getter
+        adapter = getAdapter(self.layer['folder1'], IDataCollector,
+                             name="portlet_data_adapter")
+        data = adapter.getData()
+
+        #setter - on folder2
+        adapter2 = getAdapter(self.layer['folder2'], IDataCollector,
+                              name="portlet_data_adapter")
+        adapter2.setData(data, metadata=None)
+        right_assignments = self.get_right_assignments(self.layer['folder2'])
+        
+        self.assertTrue(isinstance(right_assignments._order, PersistentList),
+                        'The _order needs to be a persistence list')
 
     def get_right_assignments(self, context):
         return self.get_assignments(context, u'plone.rightcolumn')


### PR DESCRIPTION
Since it set the attr as regular list right now, it leads to strange behavior if you have a multi-instance setup