### PR TITLE
Add constrain types adapter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add constrain types adapter. [tinagerber]
 
 
 2.14.1 (2020-02-05)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -186,4 +186,12 @@
       </configure>
     </configure>
 
+    <configure zcml:condition="have plone-5">
+      <adapter
+        for="plone.dexterity.interfaces.IDexterityContent"
+        provides="ftw.publisher.core.interfaces.IDataCollector"
+        factory="ftw.publisher.core.adapters.constrain_types.ConstrainTypesDataCollector"
+        name="constrain_types_adapter" />
+    </configure>
+
 </configure>

--- a/ftw/publisher/core/adapters/constrain_types.py
+++ b/ftw/publisher/core/adapters/constrain_types.py
@@ -1,0 +1,22 @@
+from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
+from zope.component import queryAdapter
+
+
+class ConstrainTypesDataCollector(object):
+
+    def __init__(self, obj):
+        self.constrains = queryAdapter(obj, ISelectableConstrainTypes)
+
+    def getData(self):
+        data = {}
+        if self.constrains:
+            data['mode'] = self.constrains.getConstrainTypesMode()
+            data['locally_allowed'] = self.constrains.getLocallyAllowedTypes()
+            data['immediately_addable'] = self.constrains.getImmediatelyAddableTypes()
+        return data
+
+    def setData(self, data, metadata):
+        if data:
+            self.constrains.setConstrainTypesMode(data['mode'])
+            self.constrains.setLocallyAllowedTypes(data['locally_allowed'])
+            self.constrains.setImmediatelyAddableTypes(data['immediately_addable'])

--- a/ftw/publisher/core/tests/test_constrain_types_adapter.py
+++ b/ftw/publisher/core/tests/test_constrain_types_adapter.py
@@ -1,0 +1,47 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.publisher.core.interfaces import IDataCollector
+from ftw.publisher.core.testing import PUBLISHER_CORE_INTEGRATION_TESTING
+from Products.CMFPlone.interfaces.constrains import ENABLED
+from Products.CMFPlone.interfaces.constrains import IConstrainTypes
+from Products.CMFPlone.interfaces.constrains import ISelectableConstrainTypes
+from unittest import skipUnless
+from unittest import TestCase
+from ftw.testing import IS_PLONE_5
+from zope.component import getAdapter
+
+
+@skipUnless(IS_PLONE_5, 'Test constrain types adapter for Plone 5')
+class TestConstrainTypesAdapter(TestCase):
+
+    layer = PUBLISHER_CORE_INTEGRATION_TESTING
+
+    def test_data_getter(self):
+        folder = create(Builder('folder').titled(u'The Folder'))
+        constrain_types = ISelectableConstrainTypes(folder)
+        constrain_types.setConstrainTypesMode(ENABLED)
+        allowed_types = ['Collection', 'Folder']
+        immediately_addable_types = ['Collection']
+        constrain_types.setLocallyAllowedTypes(allowed_types)
+        constrain_types.setImmediatelyAddableTypes(immediately_addable_types)
+
+        adapter = getAdapter(folder, IDataCollector, name='constrain_types_adapter')
+
+        expected_data = {'mode': ENABLED, 'locally_allowed': allowed_types,
+                         'immediately_addable': immediately_addable_types}
+        self.assertEquals(expected_data, adapter.getData())
+
+    def test_data_setter(self):
+        folder = create(Builder('folder').titled(u'The Folder'))
+
+        adapter = getAdapter(folder, IDataCollector, name='constrain_types_adapter')
+        allowed_types = ['Collection', 'Document', 'Folder']
+        immediately_addable_types = ['Collection', 'Folder']
+        adapter.setData({'mode': ENABLED, 'locally_allowed': allowed_types,
+                         'immediately_addable': immediately_addable_types},
+                        metadata=None)
+
+        constrain_types = IConstrainTypes(folder)
+        self.assertEquals(ENABLED, constrain_types.getConstrainTypesMode())
+        self.assertEquals(allowed_types, constrain_types.getLocallyAllowedTypes())
+        self.assertEquals(immediately_addable_types, constrain_types.getImmediatelyAddableTypes())


### PR DESCRIPTION
It's possible to restrict addable types. In plone 5, these settings weren't published. With the new adapter the settings are published.
Part of https://github.com/4teamwork/ogb/issues/180