### PR TITLE
Fix timezone transfer from sender to receiver

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.14.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix transfer of date and time objects [Nachtalb]
+- Fix timezone transfer of datetime and time objects [Nachtalb]
 
 
 2.14.2 (2020-02-26)

--- a/ftw/publisher/core/tests/interfaces.py
+++ b/ftw/publisher/core/tests/interfaces.py
@@ -2,6 +2,7 @@ from plone.app.textfield import RichText
 from plone.directives import form
 from plone.namedfile.field import NamedFile
 from plone.namedfile.field import NamedImage
+from zope import schema
 
 
 class IFoo(form.Schema):
@@ -24,3 +25,12 @@ class ITextSchema(form.Schema):
 
     form.primary('text')
     text = RichText(title=u'Text')
+
+
+class IDateAndTimeSchema(form.Schema):
+
+    form.primary('datetime')
+    zope_datetime = schema.Datetime(title=u'Zope Datetime')
+    datetime = schema.Datetime(title=u'Datetime')
+    date = schema.Date(title=u'Date')
+    time = schema.Time(title=u'Time')

--- a/ftw/publisher/core/tests/profiles/dexterity/types.xml
+++ b/ftw/publisher/core/tests/profiles/dexterity/types.xml
@@ -3,4 +3,5 @@
     <object name="DXFile" meta_type="Dexterity FTI" />
     <object name="DXImage" meta_type="Dexterity FTI" />
     <object name="DXText" meta_type="Dexterity FTI" />
+    <object name="DXDateAndTime" meta_type="Dexterity FTI" />
 </object>

--- a/ftw/publisher/core/tests/profiles/dexterity/types/DXDateAndTime.xml
+++ b/ftw/publisher/core/tests/profiles/dexterity/types/DXDateAndTime.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<object name="DXDateAndTime"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.publisher.core.tests" >
+
+    <!-- Basic metadata -->
+    <property name="title">DXDateAndTime</property>
+    <property name="global_allow">True</property>
+    <property name="add_permission">cmf.AddPortalContent</property>
+
+    <!-- schema interface -->
+    <property name="schema">ftw.publisher.core.tests.interfaces.IDateAndTimeSchema</property>
+
+    <!-- class used for content items -->
+    <property name="klass">plone.dexterity.content.Item</property>
+
+    <!-- enabled behaviors -->
+    <property name="behaviors">
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="plone.app.content.interfaces.INameFromTitle" />
+    </property>
+
+    <!-- View information -->
+    <property name="default_view">view</property>
+    <property name="default_view_fallback">False</property>
+    <property name="view_methods">
+        <element value="view"/>
+    </property>
+
+    <!-- Method aliases -->
+    <alias from="(Default)" to="(dynamic view)"/>
+    <alias from="edit" to="@@edit"/>
+    <alias from="sharing" to="@@sharing"/>
+    <alias from="view" to="(selected layout)"/>
+
+    <!-- Actions -->
+    <action
+        action_id="view"
+        title="View"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}"
+        visible="True">
+        <permission value="View"/>
+    </action>
+
+    <action
+        action_id="edit"
+        title="Edit"
+        category="object"
+        condition_expr=""
+        url_expr="string:${object_url}/edit"
+        visible="True">
+        <permission value="Modify portal content"/>
+    </action>
+
+</object>


### PR DESCRIPTION
Two problems existed:
- The datetime was not always transferred as ISO-8601 formatted string
- The timezone was converted to GTM on the receiving side. The `pytz`
  module does not understand GMT timezones except for GMT+0 (which is why
  it worked until now)

Possible solutions:
- Correct the timezone to something understandable by `pytz` on the
  receiver side.
- Send the timezone separately as something that `pytz` already
  understands.

We choose solution two because it is easier to implement. For solution 1
we would have had to create our own `GMT` parser that makes it `pytz`
compatible or get another package to do it.

With the second solution, we just strip the timezone and send separately
to get a string on the receiver side which `pytz` already understands.
This, however, means we need to change both sides and add additional
conditions for `Date` and `Time` objects.

We stripped the datetime object's timezone and did not recalculate it to
UTC because it would require additional conditions. That is because not
all timezone aware objects implement a recalculating method like the
`datetime.datetime` objects `.astimezone(...)`.

In addition to the timezone we now also make sure that when we get a
date (not a datetime) that it is set as a date again. The same for time
objects. Before these changes, the receiver created used a datetime
object for those values too instead of simple date and a time object.
