### PR TITLE
Extract constrain types ONLY when behavior is set

### DIFF
--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -188,7 +188,7 @@
 
     <configure zcml:condition="have plone-5">
       <adapter
-        for="plone.dexterity.interfaces.IDexterityContent"
+        for="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"
         provides="ftw.publisher.core.interfaces.IDataCollector"
         factory="ftw.publisher.core.adapters.constrain_types.ConstrainTypesDataCollector"
         name="constrain_types_adapter" />


### PR DESCRIPTION
This fixes tests in ftw.publisher.sender and ftw.publisher.receiver

WIP - as it needs a test of it's own