### PR TITLE
ftw.logo integration - create new cachkey upon receiving a logo.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ftw.logo integration: create new cachkey upon receiving a logo. [mathias.leimgruber]
 
 
 2.14.4 (2020-03-20)

--- a/ftw/publisher/core/adapters/configure.zcml
+++ b/ftw/publisher/core/adapters/configure.zcml
@@ -194,4 +194,14 @@
         name="constrain_types_adapter" />
     </configure>
 
+    <!-- ftw.logo -->
+    <configure zcml:condition="installed ftw.logo">
+      <configure zcml:condition="installed ftw.publisher.receiver">
+        <subscriber
+          for="ftw.logo.manual_override.IManualOverrides
+               ftw.publisher.receiver.interfaces.IAfterUpdatedEvent"
+          handler=".ftw_logo.trigger_modified" />
+        </configure>
+    </configure>
+
 </configure>

--- a/ftw/publisher/core/adapters/ftw_logo.py
+++ b/ftw/publisher/core/adapters/ftw_logo.py
@@ -1,0 +1,4 @@
+
+def trigger_modified(obj, event):
+    from ftw.logo.manual_override import overrides_changed
+    overrides_changed(obj, event)


### PR DESCRIPTION
This forces the creation of a new cachkey, which forces the browser to show a new logo, even if it's caches by a proxy.