### PR TITLE
Fix collective.z3cform.datagridfield import.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.14.6 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix collective.z3cform.datagridfield import. [mathias.leimgruber]
 
 
 2.14.5 (2020-10-12)

--- a/ftw/publisher/core/tests/behaviors.py
+++ b/ftw/publisher/core/tests/behaviors.py
@@ -1,5 +1,5 @@
-from collective.z3cform.datagridfield import DataGridFieldFactory
-from collective.z3cform.datagridfield import DictRow
+from collective.z3cform.datagridfield.datagridfield import DataGridFieldFactory
+from collective.z3cform.datagridfield.row import DictRow
 from ftw.referencewidget.sources import ReferenceObjSourceBinder
 from ftw.referencewidget.widget import ReferenceWidgetFactory
 from plone.autoform import directives

--- a/test-plone-5.1.x-trash.cfg
+++ b/test-plone-5.1.x-trash.cfg
@@ -9,3 +9,7 @@ package-name = ftw.publisher.core
 [test]
 eggs +=
     ftw.trash
+
+
+[versions]
+ftw.servicenavigation = >1.3.1

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -6,3 +6,7 @@ extends =
 package-name = ftw.publisher.core
 
 auto-checkout =
+
+
+[versions]
+ftw.servicenavigation = >1.3.1


### PR DESCRIPTION
See
https://github.com/collective/collective.z3cform.datagridfield/commit/3d4064a47a9062394acab8f2b65e61025875a150#diff-b7466768d5acffdf1a9b06abfb886a06ff495ef020cc04fea1b3d42b622c1c48

Thus the shorter module import did no longer work.